### PR TITLE
Game view mouse events

### DIFF
--- a/src/tilematch_tools/view/__init__.py
+++ b/src/tilematch_tools/view/__init__.py
@@ -4,7 +4,7 @@
     :module_author: Matthew Isayan, Nathan Mendoza
 """
 
-from .game_event import GameEvent
+from .game_event import GameEvent, MouseEvent
 from .game_widgets import GameWidget, GameInfo
 from .score_view import ScoreView
 from .board_view import BoardView

--- a/src/tilematch_tools/view/__init__.py
+++ b/src/tilematch_tools/view/__init__.py
@@ -1,9 +1,10 @@
 """
     :module_name: view
     :module_summary: a module responsible for the view of the tile game
-    :module_author: Matthew Isayan
+    :module_author: Matthew Isayan, Nathan Mendoza
 """
 
+from .game_event import GameEvent
 from .game_widgets import GameWidget, GameInfo
 from .score_view import ScoreView
 from .board_view import BoardView

--- a/src/tilematch_tools/view/board_view.py
+++ b/src/tilematch_tools/view/board_view.py
@@ -35,6 +35,10 @@ class BoardView(GameInfo):
         return self._watching
 
     @property
+    def showing(self):
+        return self._board_display
+
+    @property
     def board_height(self):
         return self.tile_side_length * self.watching.num_rows
 

--- a/src/tilematch_tools/view/game_event.py
+++ b/src/tilematch_tools/view/game_event.py
@@ -1,0 +1,37 @@
+"""
+    :module_name: game_event
+    :module_summary: interface for tilmatching game events
+    :module_author: Nathan Mendoza (nathancm@uci.edu)
+"""
+
+import tkinter as tk
+
+
+from ..core import GameState
+
+class GameEvent:
+    """
+        Class represent an abstract game event
+    """
+
+    def __init__(self, listener: GameState):
+        self._listener = listener
+
+    @property
+    def listener(self) -> GameState:
+        """
+            Reference to the object that knows how to respond to this event
+            :returns: object awaiting this event
+            :rtype: GameState
+        """
+        return self._listener
+
+    def __call__(self, event: tk.Event) -> None:
+        """
+            Logic for responding to this event. AKA the "event handler"
+            :arg event: event triggering this response
+            :arg type: tk.Event
+            :returns: nothing
+            :rtype: None
+        """
+        pass

--- a/src/tilematch_tools/view/game_event.py
+++ b/src/tilematch_tools/view/game_event.py
@@ -8,6 +8,7 @@ import tkinter as tk
 
 
 from ..core import GameState
+from .board_view import BoardView
 
 class GameEvent:
     """
@@ -35,3 +36,16 @@ class GameEvent:
             :rtype: None
         """
         pass
+
+class MouseEvent(GameEvent):
+    def __init__(self, listener: GameState, board_clicked_on: BoardView):
+        super().__init__(listener)
+        self.board_display = board_clicked_on
+
+    def __call__(self, event):
+        object_clicked_on = event.widget.find_closest(event.x, event.y)
+        if object_clicked_on:
+            for tile, drawing in self.board_display.tiles_map.items():
+                if drawing == object_clicked_on[0]:
+                    return tile
+             

--- a/src/tilematch_tools/view/game_view.py
+++ b/src/tilematch_tools/view/game_view.py
@@ -35,6 +35,14 @@ class GameView(GameWidget):
         for w in self._game_widgets.values():
             w.update()
 
+    @property
+    def board_view(self):
+        return self._game_widgets['board']
+
+    @property
+    def score_view(self):
+        return self._game_widgets['score']
+
     def bind_key(self, key_sequence: str, handler: GameEvent) -> None:
         self.bind_all(key_sequence, handler)
 

--- a/src/tilematch_tools/view/game_view.py
+++ b/src/tilematch_tools/view/game_view.py
@@ -33,4 +33,10 @@ class GameView(GameWidget):
     def update(self):
         for w in self._game_widgets.values():
             w.update()
+
+    def bind_key(self, key_sequence: str, handler: callable) -> None:
+        self.bind_all(key_sequence, handler)
+
+    def bind_click(self, mouse_button: str, handler: callable) -> None:
+        self._game_widgets['board'].showing.bind(mouse_button, handler)
         

--- a/src/tilematch_tools/view/game_view.py
+++ b/src/tilematch_tools/view/game_view.py
@@ -10,6 +10,7 @@ from ..core import GameState
 from .score_view import ScoreView
 from .board_view import BoardView
 from .game_widgets import GameWidget
+from .game_event import GameEvent
 
 class GameView(GameWidget):
     """
@@ -34,9 +35,9 @@ class GameView(GameWidget):
         for w in self._game_widgets.values():
             w.update()
 
-    def bind_key(self, key_sequence: str, handler: callable) -> None:
+    def bind_key(self, key_sequence: str, handler: GameEvent) -> None:
         self.bind_all(key_sequence, handler)
 
-    def bind_click(self, mouse_button: str, handler: callable) -> None:
+    def bind_click(self, mouse_button: str, handler: GameEvent) -> None:
         self._game_widgets['board'].showing.bind(mouse_button, handler)
         

--- a/test/unit/view/test_game_view.py
+++ b/test/unit/view/test_game_view.py
@@ -88,10 +88,10 @@ def test_game_view_update_cycle(simple_game_state, move_rule_up, move_rule_down,
         move_rule_right.move(simple_game_state.board, moving_tile)
         simple_game_state.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
 
-    game_view.bind_all('<KeyRelease-w>', move_up)
-    game_view.bind_all('<KeyRelease-s>', move_dn)
-    game_view.bind_all('<KeyRelease-a>', move_left)
-    game_view.bind_all('<KeyRelease-d>', move_right)
+    game_view.bind_key('<KeyRelease-w>', move_up)
+    game_view.bind_key('<KeyRelease-s>', move_dn)
+    game_view.bind_key('<KeyRelease-a>', move_left)
+    game_view.bind_key('<KeyRelease-d>', move_right)
 
     def update():
         game_view.update()
@@ -145,10 +145,10 @@ def test_independent_game_view_bindings(move_rule_up, move_rule_down, move_rule_
         move_rule_right.move(gs1.board, moving_tile1)
         gs1.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
 
-    gv1.bind_all('<KeyRelease-w>', move_up1)
-    gv1.bind_all('<KeyRelease-s>', move_dn1)
-    gv1.bind_all('<KeyRelease-a>', move_left1)
-    gv1.bind_all('<KeyRelease-d>', move_right1)
+    gv1.bind_key('<KeyRelease-w>', move_up1)
+    gv1.bind_key('<KeyRelease-s>', move_dn1)
+    gv1.bind_key('<KeyRelease-a>', move_left1)
+    gv1.bind_key('<KeyRelease-d>', move_right1)
 
     def move_up2(event):
         move_rule_up.move(gs2.board, moving_tile2)
@@ -166,10 +166,10 @@ def test_independent_game_view_bindings(move_rule_up, move_rule_down, move_rule_
         move_rule_right.move(gs2.board, moving_tile2)
         gs2.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
 
-    gv2.bind_all('<KeyRelease-i>', move_up2)
-    gv2.bind_all('<KeyRelease-k>', move_dn2)
-    gv2.bind_all('<KeyRelease-j>', move_left2)
-    gv2.bind_all('<KeyRelease-l>', move_right2)
+    gv2.bind_key('<KeyRelease-i>', move_up2)
+    gv2.bind_key('<KeyRelease-k>', move_dn2)
+    gv2.bind_key('<KeyRelease-j>', move_left2)
+    gv2.bind_key('<KeyRelease-l>', move_right2)
 
     def update():
         gv1.update()

--- a/test/unit/view/test_game_view.py
+++ b/test/unit/view/test_game_view.py
@@ -7,7 +7,7 @@ import pytest
 
 from tilematch_tools.core import GameState, BoardFactory, TileBuilder
 from tilematch_tools.model import Scoring, GameBoard, MovementRule, Tile, TileColor, MatchCondition
-from tilematch_tools.view import GameView
+from tilematch_tools.view import GameView, GameEvent
 
 @pytest.fixture
 def simple_game_state():
@@ -71,27 +71,31 @@ def test_game_view_update_cycle(simple_game_state, move_rule_up, move_rule_down,
     root = tk.Tk()
     game_view = GameView(root, simple_game_state)
     game_view.pack()
-    
-    def move_up(event):
-        move_rule_up.move(simple_game_state.board, moving_tile)
-        simple_game_state.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
 
-    def move_dn(event):
-        move_rule_down.move(simple_game_state.board, moving_tile)
-        simple_game_state.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+    class MoveUp(GameEvent):
+        def __call__(self, event):
+            move_rule_up.move(self.listener.board, moving_tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))
+ 
+    class MoveDown(GameEvent):
+        def __call__(self, event):
+            move_rule_down.move(self.listener.board, moving_tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))
 
-    def move_left(event):
-        move_rule_left.move(simple_game_state.board, moving_tile)
-        simple_game_state.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+    class MoveLeft(GameEvent):
+        def __call__(self, event):
+            move_rule_left.move(self.listener.board, moving_tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))
 
-    def move_right(event):
-        move_rule_right.move(simple_game_state.board, moving_tile)
-        simple_game_state.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
-
-    game_view.bind_key('<KeyRelease-w>', move_up)
-    game_view.bind_key('<KeyRelease-s>', move_dn)
-    game_view.bind_key('<KeyRelease-a>', move_left)
-    game_view.bind_key('<KeyRelease-d>', move_right)
+    class MoveRight(GameEvent):
+        def __call__(self, event):
+            move_rule_right.move(self.listener.board, moving_tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))   
+   
+    game_view.bind_key('<KeyRelease-w>', MoveUp(simple_game_state))
+    game_view.bind_key('<KeyRelease-s>', MoveDown(simple_game_state))
+    game_view.bind_key('<KeyRelease-a>', MoveLeft(simple_game_state))
+    game_view.bind_key('<KeyRelease-d>', MoveRight(simple_game_state))
 
     def update():
         game_view.update()
@@ -129,47 +133,52 @@ def test_independent_game_view_bindings(move_rule_up, move_rule_down, move_rule_
     gv1.grid(row=0, column=0)
     gv2.grid(row=0, column=1)
     
-    def move_up1(event):
-        move_rule_up.move(gs1.board, moving_tile1)
-        gs1.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+    class MoveUp(GameEvent):
+        def __init__(self, listener, tile):
+            super().__init__(listener)
+            self.tile = tile
 
-    def move_dn1(event):
-        move_rule_down.move(gs1.board, moving_tile1)
-        gs1.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+        def __call__(self, event):
+            move_rule_up.move(self.listener.board, self.tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))
+ 
+    class MoveDown(GameEvent):
+        def __init__(self, listener, tile):
+            super().__init__(listener)
+            self.tile = tile
 
-    def move_left1(event):
-        move_rule_left.move(gs1.board, moving_tile1)
-        gs1.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+        def __call__(self, event):
+            move_rule_down.move(self.listener.board, self.tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))
 
-    def move_right1(event):
-        move_rule_right.move(gs1.board, moving_tile1)
-        gs1.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+    class MoveLeft(GameEvent):
+        def __init__(self, listener, tile):
+            super().__init__(listener)
+            self.tile = tile
 
-    gv1.bind_key('<KeyRelease-w>', move_up1)
-    gv1.bind_key('<KeyRelease-s>', move_dn1)
-    gv1.bind_key('<KeyRelease-a>', move_left1)
-    gv1.bind_key('<KeyRelease-d>', move_right1)
+        def __call__(self, event):
+            move_rule_left.move(self.listener.board, self.tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))
 
-    def move_up2(event):
-        move_rule_up.move(gs2.board, moving_tile2)
-        gs2.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+    class MoveRight(GameEvent):
+        def __init__(self, listener, tile):
+            super().__init__(listener)
+            self.tile = tile
 
-    def move_dn2(event):
-        move_rule_down.move(gs2.board, moving_tile2)
-        gs2.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+        def __call__(self, event):
+            move_rule_right.move(self.listener.board, self.tile)
+            self.listener.adjust_score(MatchCondition.MatchFound(random.randint(5, 10), []))   
+    
 
-    def move_left2(event):
-        move_rule_left.move(gs2.board, moving_tile2)
-        gs2.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
+    gv1.bind_key('<KeyRelease-w>', MoveUp(gs1, moving_tile1))
+    gv1.bind_key('<KeyRelease-s>', MoveDown(gs1, moving_tile1))
+    gv1.bind_key('<KeyRelease-a>', MoveLeft(gs1, moving_tile1))
+    gv1.bind_key('<KeyRelease-d>', MoveRight(gs1, moving_tile1))
 
-    def move_right2(event):
-        move_rule_right.move(gs2.board, moving_tile2)
-        gs2.adjust_score(MatchCondition.MatchFound(random.randint(10, 50), []))
-
-    gv2.bind_key('<KeyRelease-i>', move_up2)
-    gv2.bind_key('<KeyRelease-k>', move_dn2)
-    gv2.bind_key('<KeyRelease-j>', move_left2)
-    gv2.bind_key('<KeyRelease-l>', move_right2)
+    gv2.bind_key('<KeyRelease-i>', MoveUp(gs2, moving_tile2))
+    gv2.bind_key('<KeyRelease-k>', MoveDown(gs2, moving_tile2))
+    gv2.bind_key('<KeyRelease-j>', MoveLeft(gs2, moving_tile2))
+    gv2.bind_key('<KeyRelease-l>', MoveRight(gs2, moving_tile2))
 
     def update():
         gv1.update()
@@ -178,4 +187,19 @@ def test_independent_game_view_bindings(move_rule_up, move_rule_down, move_rule_
 
     root.after(100, update)
     root.mainloop()
+
+
+
+@pytest.mark.skip
+def test_mouse_click_events(simple_game_state):
+    moving_tile = TileBuilder() \
+            .add_position(random.randint(1, simple_game_state.board.num_cols), random.randint(1, simple_game_state.board.num_rows)) \
+            .add_color(random.choice(list(TileColor))) \
+            .construct()
+    simple_game_state.board.place_tile(moving_tile)
+
+
+    root = tk.Tk()
+    game_view = GameView(root, simple_game_state)
+    game_view.pack()
 


### PR DESCRIPTION
- Introduce the `GameEvent` interface
    - Your game events should extend this class and pass them when binding events during `GameLoop` construction
    - A `MouseEvent` subclass is provided to get the tile coordinates of a mouse click event on a particular board view
- Mouse clicks are only registered on a particular board, and have unparalleled accuracy and responsiveness just like key events